### PR TITLE
add support for defining macros on command line

### DIFF
--- a/extern.h
+++ b/extern.h
@@ -355,9 +355,11 @@ struct macro {
 	unsigned int		 mc_flags;
 #define MACRO_FLAG_STATIC	0x00000001u	/* storage provided by ml_v */
 #define MACRO_FLAG_CONST	0x00000002u	/* may not be freed */
+#define MACRO_FLAG_IMMUTABLE	0x00000004u	/* not overriden, replace */
 
 	TAILQ_ENTRY(macro)	 mc_entry;
 };
+
 
 struct macro_list {
 	struct macro		ml_v[2];
@@ -365,10 +367,11 @@ struct macro_list {
 	size_t			ml_size;
 	unsigned int		ml_ctx;
 
-	TAILQ_HEAD(, macro)	ml_list;
+	TAILQ_HEAD(ml_list, macro) ml_list;
 };
 
 void		 macros_init(struct macro_list *, unsigned int);
+void		 macros_free(struct macro_list *);
 int		 macros_insert(struct macro_list *, char *, char *, unsigned int, int);
 void		 macros_insertc(struct macro_list *, const char *,
     const char *);
@@ -394,7 +397,7 @@ struct config_list {
 	TAILQ_HEAD(, config)	 cf_list;
 };
 
-struct config_list	*config_parse(const char *, const struct environment *);
+struct config_list	*config_parse(const char *, struct macro_list *, const struct environment *);
 void			 config_free(struct config_list *);
 
 /*

--- a/extern.h
+++ b/extern.h
@@ -351,6 +351,7 @@ struct macro {
 	char			*mc_name;
 	char			*mc_value;
 	unsigned int		 mc_refs;
+	unsigned int		 mc_defs;
 	unsigned int		 mc_lno;
 	unsigned int		 mc_flags;
 #define MACRO_FLAG_STATIC	0x00000001u	/* storage provided by ml_v */
@@ -373,8 +374,6 @@ struct macro_list {
 void		 macros_init(struct macro_list *, unsigned int);
 void		 macros_free(struct macro_list *);
 int		 macros_insert(struct macro_list *, char *, char *, unsigned int, int);
-void		 macros_insertc(struct macro_list *, const char *,
-    const char *);
 struct macro	*macros_find(const struct macro_list *, const char *);
 unsigned int	 macro_context(const char *);
 

--- a/extern.h
+++ b/extern.h
@@ -369,7 +369,7 @@ struct macro_list {
 };
 
 void		 macros_init(struct macro_list *, unsigned int);
-int		 macros_insert(struct macro_list *, char *, char *, int);
+int		 macros_insert(struct macro_list *, char *, char *, unsigned int, int);
 void		 macros_insertc(struct macro_list *, const char *,
     const char *);
 struct macro	*macros_find(const struct macro_list *, const char *);

--- a/match.c
+++ b/match.c
@@ -87,7 +87,8 @@ matches_interpolate(struct match_list *ml)
 
 	/* Construct action macro context. */
 	macros_init(&macros, MACRO_CTX_ACTION);
-	macros_insertc(&macros, "path", TAILQ_FIRST(ml)->mh_msg->me_path);
+	macros_insert(&macros, "path", TAILQ_FIRST(ml)->mh_msg->me_path,
+	    MACRO_FLAG_STATIC | MACRO_FLAG_CONST, 0);
 
 	TAILQ_FOREACH(mh, ml, mh_entry) {
 		if (match_interpolate(mh, &macros))

--- a/mdsort.1
+++ b/mdsort.1
@@ -7,6 +7,7 @@
 .Sh SYNOPSIS
 .Nm
 .Op Fl dnv
+.Op Fl D Ar macro=value
 .Op Fl f Ar file
 .Op Fl
 .Sh DESCRIPTION
@@ -26,6 +27,12 @@ output which messages would be moved with respect to the current rules.
 Specify an alternative configuration file.
 .It Fl n
 Check if the configuration file is valid.
+.It Fl D Ar macro=value
+Define
+.Ar macro
+to be set to
+.Ar value
+on the command line.
 .It Fl v
 Verbose mode.
 Multiple

--- a/mdsort.c
+++ b/mdsort.c
@@ -79,8 +79,7 @@ main(int argc, char *argv[])
 			if ((eq = strchr(optarg, '=')) == NULL)
 				err(1, "invalid macro: %s", optarg);
 			*eq = '\0';
-			flags = MACRO_FLAG_CONST;
-			flags |= MACRO_FLAG_STATIC;
+			flags = MACRO_FLAG_CONST | MACRO_FLAG_STATIC;
 			flags |= MACRO_FLAG_IMMUTABLE;
 			macros_insert(&macros, optarg, eq + 1, flags, 0);
 			break;

--- a/parse.y
+++ b/parse.y
@@ -123,7 +123,7 @@ grammar		: /* empty */
 
 macro		: MACRO '=' STRING {
 			$3 = expand($3, MACRO_CTX_DEFAULT);
-			if (macros_insert(yyconfig.cf_macros, $1, $3, lineno))
+			if (macros_insert(yyconfig.cf_macros, $1, $3, 0, lineno))
 				yyerror("macro already defined: %s", $1);
 		}
 		;

--- a/util.c
+++ b/util.c
@@ -112,7 +112,8 @@ macros_init(struct macro_list *macros, unsigned int ctx)
 }
 
 int
-macros_insert(struct macro_list *macros, char *name, char *value, int lno)
+macros_insert(struct macro_list *macros, char *name, char *value,
+    unsigned int flags, int lno)
 {
 	struct macro *mc;
 
@@ -123,12 +124,12 @@ macros_insert(struct macro_list *macros, char *name, char *value, int lno)
 
 	if (macros->ml_nmemb < macros->ml_size) {
 		mc = &macros->ml_v[macros->ml_nmemb++];
-		mc->mc_flags = MACRO_FLAG_STATIC;
+		mc->mc_flags = flags | MACRO_FLAG_STATIC;
 	} else {
 		mc = malloc(sizeof(*mc));
 		if (mc == NULL)
 			err(1, NULL);
-		mc->mc_flags = 0;
+		mc->mc_flags = flags;
 	}
 
 	mc->mc_name = name;


### PR DESCRIPTION
Command-line defined macros are useful to define specific parameters to
one invocation of a program.

For example: ls | xargs -I {} mdsort -D box={} -f ~/.mdsort/archive.conf

The free function had to be moved to util.c as it gets used by mdsort.c.

The current patch does not allow overriding macros from the config file yet.